### PR TITLE
Add regex strip for usernames to remove unicode emojis

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -88,6 +88,7 @@
     "other": {
       "messageMode": "bot",
       "messageFormat": "{chatType} > {skin} {rank} {username} {guildRank}§f: {message}",
+      "stripEmojisFromUsernames": true,
       "filterMessages": true,
       "filterWords": ["dox", "doxx", "doxed", "doxxed", "doxing", "doxxing", "doxes", "doxxes"],
       "joinMessage": true,

--- a/src/minecraft/MinecraftManager.js
+++ b/src/minecraft/MinecraftManager.js
@@ -70,6 +70,14 @@ class MinecraftManager extends CommunicationBridge {
       }
     }
 
+    if (config.discord.other.stripEmojisFromUsernames) {
+      try {
+        username = username.replace(/:[\w\-_]+:/g, '');
+      } catch (error) {
+        // Do nothing
+      }
+    }
+
     message = replaceVariables(config.minecraft.bot.messageFormat, { username, message });
 
     const chat = channel === config.discord.channels.officerChannel ? "/oc" : "/gc";


### PR DESCRIPTION
This filters out emojis from discord usernames from Discord -> Minecraft